### PR TITLE
support relative file system paths

### DIFF
--- a/identities/identity_config.go
+++ b/identities/identity_config.go
@@ -19,7 +19,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"net/url"
 
 	"github.com/greymatter-io/nautls/internal/urls"
 	"github.com/pkg/errors"
@@ -173,12 +172,7 @@ func decodeKeys(bytes []byte) ([]*rsa.PrivateKey, error) {
 // loadResource loads a resource URL into a byte array.
 func loadResource(resource string) ([]byte, error) {
 
-	parsed, err := url.Parse(resource)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error parsing url from [%s]", resource)
-	}
-
-	bytes, err := urls.ReadFile(parsed)
+	bytes, err := urls.ReadFile(resource)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error reading resource from [%s]", resource)
 	}

--- a/identities/identity_config_test.go
+++ b/identities/identity_config_test.go
@@ -16,7 +16,6 @@ package identities
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/greymatter-io/nautls/internal/tests"
@@ -32,14 +31,14 @@ func TestIdentityConfig(t *testing.T) {
 		Convey(".Build is invoked", func() {
 
 			config := &IdentityConfig{
-				Authorities: fmt.Sprintf("file://%s", tests.MustAbsolutePath("testdata/multiple.crt", t)),
-				Certificate: fmt.Sprintf("file://%s", tests.MustAbsolutePath("testdata/single.crt", t)),
-				Key:         fmt.Sprintf("file://%s", tests.MustAbsolutePath("testdata/single.key", t)),
+				Authorities: "./testdata/multiple.crt",
+				Certificate: "./testdata/single.crt",
+				Key:         "./testdata/single.key",
 			}
 
 			Convey("with empty authorities", func() {
 
-				config.Authorities = fmt.Sprintf("file://%s", tests.MustAbsolutePath("testdata/empty.crt", t))
+				config.Authorities = "./testdata/empty.crt"
 				identity, err := config.Build()
 
 				Convey("it should return a non-nil identity", func() {
@@ -53,7 +52,7 @@ func TestIdentityConfig(t *testing.T) {
 
 			Convey("with invalid authorities", func() {
 
-				config.Authorities = fmt.Sprintf("file://%s", tests.MustAbsolutePath("testdata/invalid.crt", t))
+				config.Authorities = "./testdata/invalid.crt"
 				identity, err := config.Build()
 
 				Convey("it should return a nil identity", func() {
@@ -67,7 +66,7 @@ func TestIdentityConfig(t *testing.T) {
 
 			Convey("with an empty certificate", func() {
 
-				config.Certificate = fmt.Sprintf("file://%s", tests.MustAbsolutePath("testdata/empty.crt", t))
+				config.Certificate = "./testdata/empty.crt"
 				identity, err := config.Build()
 
 				Convey("it should return a nil identity", func() {
@@ -81,7 +80,7 @@ func TestIdentityConfig(t *testing.T) {
 
 			Convey("with an invalid certificate", func() {
 
-				config.Certificate = fmt.Sprintf("file://%s", tests.MustAbsolutePath("testdata/invalid.crt", t))
+				config.Certificate = "./testdata/invalid.crt"
 				identity, err := config.Build()
 
 				Convey("it should return a nil identity", func() {
@@ -95,7 +94,7 @@ func TestIdentityConfig(t *testing.T) {
 
 			Convey("with multiple certificates", func() {
 
-				config.Certificate = fmt.Sprintf("file://%s", tests.MustAbsolutePath("testdata/multiple.crt", t))
+				config.Certificate = "./testdata/multiple.crt"
 				identity, err := config.Build()
 
 				Convey("it should return a nil identity", func() {
@@ -109,7 +108,7 @@ func TestIdentityConfig(t *testing.T) {
 
 			Convey("with an empty key", func() {
 
-				config.Key = fmt.Sprintf("file://%s", tests.MustAbsolutePath("testdata/empty.key", t))
+				config.Key = "./testdata/empty.key"
 				identity, err := config.Build()
 
 				Convey("it should return a nil identity", func() {
@@ -123,7 +122,7 @@ func TestIdentityConfig(t *testing.T) {
 
 			Convey("with an invalid key", func() {
 
-				config.Key = fmt.Sprintf("file://%s", tests.MustAbsolutePath("testdata/invalid.key", t))
+				config.Key = "./testdata/invalid.key"
 				identity, err := config.Build()
 
 				Convey("it should return a nil identity", func() {
@@ -137,7 +136,7 @@ func TestIdentityConfig(t *testing.T) {
 
 			Convey("with multiple keys", func() {
 
-				config.Key = fmt.Sprintf("file://%s", tests.MustAbsolutePath("testdata/multiple.key", t))
+				config.Key = "./testdata/multiple.key"
 				identity, err := config.Build()
 
 				Convey("it should return a nil identity", func() {

--- a/internal/tests/io.go
+++ b/internal/tests/io.go
@@ -17,6 +17,7 @@ package tests
 import (
 	"crypto/tls"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -46,4 +47,20 @@ func MustLoadX509KeyPair(certificate string, key string, test *testing.T) tls.Ce
 		test.Errorf("error reading key pair [%s]", err)
 	}
 	return c
+}
+
+// MustRelativePath returns the relative path for the current working directory or fails the test.
+func MustRelativePath(absolute string, test *testing.T) string {
+
+	working, err := os.Getwd()
+	if err != nil {
+		test.Errorf("error getting current working directory [%s]", err)
+	}
+
+	relative, err := filepath.Rel(working, absolute)
+	if err != nil {
+		test.Errorf("error resolving relative path [%s]", err)
+	}
+
+	return relative
 }

--- a/internal/urls/urls_test.go
+++ b/internal/urls/urls_test.go
@@ -16,6 +16,7 @@ package urls
 
 import (
 	"encoding/base64"
+	"fmt"
 	"net/url"
 	"testing"
 
@@ -29,10 +30,27 @@ func TestReadFile(test *testing.T) {
 
 	Convey("When .ReadFile is invoked", test, func() {
 
+		Convey("with no scheme", func() {
+
+			expectedContent := tests.MustGenerateBytes(test)
+			actualContent, err := temporary.WithFile(expectedContent, 0777, func(path string) (interface{}, error) {
+				resource := tests.MustRelativePath(path, test)
+				return ReadFile(resource)
+			})
+
+			Convey("it returns the content", func() {
+				So(actualContent, ShouldResemble, expectedContent)
+			})
+
+			Convey("it returns a nil error", func() {
+				So(err, ShouldBeNil)
+			})
+		})
+
 		Convey("with a base64 scheme", func() {
 
 			expectedContent := tests.MustGenerateBytes(test)
-			resource, err := url.Parse("base64:///" + url.PathEscape(base64.StdEncoding.EncodeToString(expectedContent)))
+			resource := fmt.Sprintf("base64:///%s", url.PathEscape(base64.StdEncoding.EncodeToString(expectedContent)))
 			actualContent, err := ReadFile(resource)
 
 			Convey("it returns the content", func() {
@@ -48,7 +66,7 @@ func TestReadFile(test *testing.T) {
 
 			expectedContent := tests.MustGenerateBytes(test)
 			actualContent, err := temporary.WithFile(expectedContent, 0777, func(path string) (interface{}, error) {
-				resource, _ := url.Parse("file://" + path)
+				resource := fmt.Sprintf("file://%s", path)
 				return ReadFile(resource)
 			})
 


### PR DESCRIPTION
@critterjohnson, this adds support for (or removes restrictions preventing the use of) relative file paths.  Essentially this means that you can use:

- `base64:///`
- `file:///`

As well as:

- `../../`